### PR TITLE
improve batch-wise grasp generation in sampling scripts

### DIFF
--- a/scripts/sample/generate_6d_grasp_poses.py
+++ b/scripts/sample/generate_6d_grasp_poses.py
@@ -1,67 +1,77 @@
+import configargparse
 import torch
 
 from se3dif.models.loader import load_model
-from se3dif.samplers import ApproximatedGrasp_AnnealedLD, Grasp_AnnealedLD
-import configargparse
+from se3dif.samplers import Grasp_AnnealedLD
+
 
 def parse_args():
     p = configargparse.ArgumentParser()
-    p.add('-c', '--config_filepath', required=False, is_config_file=True, help='Path to config file.')
+    p.add(
+        "-c",
+        "--config_filepath",
+        required=False,
+        is_config_file=True,
+        help="Path to config file.",
+    )
 
-    p.add_argument('--obj_id', type=str, default='15')
-    p.add_argument('--n_grasps', type=str, default='20')
+    p.add_argument("--obj_id", type=str, default="15")
+    p.add_argument("--n_grasps", type=str, default="20")
+    p.add_argument("--device", type=str, default="cpu")
+    p.add_argument("--batch_size", type=int, default=20)
 
     opt = p.parse_args()
     return opt
 
 
-def get_approximated_grasp_diffusion_field(obj_id=0):
-    model_params = 'graspdif_model'
-    batch = 15
-    device = 'cpu'
+def get_approximated_grasp_diffusion_field(obj_id=0, batch_size=15, device="cuda:0"):
+    model_params = "graspdif_model"
+
     ## Load model
-    model_args = {
-        'device': device,
-        'pretrained_model': model_params
-    }
+    model_args = {"device": device, "pretrained_model": model_params}
     model = load_model(model_args)
 
     context = torch.Tensor([[obj_id]]).to(device)
-    model.set_latent(context, batch=batch)
+    model.set_latent(context, batch_size)
 
     ########### 2. SET SAMPLING METHOD #############
-    #generator = ApproximatedGrasp_AnnealedLD(model, batch=batch, T = 30, T_fit=50)
-    generator = Grasp_AnnealedLD(model, batch=batch, T = 30, T_fit=20, k_steps=2)
+    # generator = ApproximatedGrasp_AnnealedLD(model, batch=batch, T = 30, T_fit=50)
+    generator = Grasp_AnnealedLD(
+        model, device=device, batch=batch_size, T=30, T_fit=20, k_steps=2
+    )
 
-    #generator.set_latent_code(obj_id)
+    # generator.set_latent_code(obj_id)
     return generator, model
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     args = parse_args()
 
-    print('##########################################################')
+    print("##########################################################")
     print(args.obj_id)
-    print('##########################################################')
+    print("##########################################################")
 
     n_grasps = int(args.n_grasps)
     obj_id = int(args.obj_id)
-    n_envs = 30
+    device = args.device
+    batch_size = args.batch_size
 
     ## Set Model and Sample Generator ##
-    generator, model = get_approximated_grasp_diffusion_field(obj_id)
+    generator, model = get_approximated_grasp_diffusion_field(
+        obj_id, batch_size=batch_size, device=device
+    )
 
     H = generator.sample()
-    H[..., :3, -1] *=1/8.
+    H[..., :3, -1] *= 1 / 8.0
 
     ## Visualize results ##
     from se3dif.datasets import AcronymGraspsDirectory
-    from se3dif.visualization import grasp_visualization
     from se3dif.utils import to_numpy
+    from se3dif.visualization import grasp_visualization
+
     acronym_grasps = AcronymGraspsDirectory()
     mesh = acronym_grasps.avail_obj[obj_id].load_mesh()
 
     vis_H = H.squeeze()
     grasp_visualization.visualize_grasps(to_numpy(H), mesh=mesh)
-

--- a/scripts/sample/generate_partial_pointcloud_6d_grasp_poses.py
+++ b/scripts/sample/generate_partial_pointcloud_6d_grasp_poses.py
@@ -1,105 +1,118 @@
-import scipy.spatial.transform
-import torch
-import numpy as np
-from se3dif.datasets import AcronymGraspsDirectory
-from se3dif.models.loader import load_model
-from se3dif.samplers import ApproximatedGrasp_AnnealedLD, Grasp_AnnealedLD
-from se3dif.utils import to_numpy, to_torch
 import configargparse
+import torch
+
+import numpy as np
+import scipy.spatial.transform as T
 
 from mesh_to_sdf.scan import ScanPointcloud
+from se3dif.datasets import AcronymGraspsDirectory
+from se3dif.models.loader import load_model
+from se3dif.samplers import Grasp_AnnealedLD
+from se3dif.utils import to_numpy, to_torch
 
-device = 'cpu'
 
 def parse_args():
     p = configargparse.ArgumentParser()
-    p.add('-c', '--config_filepath', required=False, is_config_file=True, help='Path to config file.')
+    p.add(
+        "-c",
+        "--config_filepath",
+        required=False,
+        is_config_file=True,
+        help="Path to config file.",
+    )
 
-    p.add_argument('--obj_id', type=str, default='12')
-    p.add_argument('--n_grasps', type=str, default='10')
-    p.add_argument('--obj_class', type=str, default='Mug')
+    p.add_argument("--obj_id", type=str, default="12")
+    p.add_argument("--n_grasps", type=str, default="20")
+    p.add_argument("--obj_class", type=str, default="Mug")
+    p.add_argument("--device", type=str, default="cpu")
+    p.add_argument("--batch_size", type=int, default=20)
 
     opt = p.parse_args()
     return opt
 
 
-def get_approximated_grasp_diffusion_field(p, device='cpu'):
-    model_params = 'partial_grasp_dif'
-    batch = 10
+def get_approximated_grasp_diffusion_field(p, batch_size=10, device="cpu"):
+    model_params = "partial_grasp_dif"
+
     ## Load model
-    model_args = {
-        'device': device,
-        'pretrained_model': model_params
-    }
+    model_args = {"device": device, "pretrained_model": model_params}
     model = load_model(model_args)
 
-    context = to_torch(p[None,...], device)
-    model.set_latent(context, batch=batch)
+    context = to_torch(p[None, ...], device)
+    model.set_latent(context, batch_size)
 
     ########### 2. SET SAMPLING METHOD #############
-    generator = Grasp_AnnealedLD(model, batch=batch, T = 70, T_fit=50, k_steps=1)
+    generator = Grasp_AnnealedLD(
+        model, device=device, batch=batch_size, T=70, T_fit=50, k_steps=1
+    )
 
-    #generator.set_latent_code(obj_id)
+    # generator.set_latent_code(obj_id)
     return generator, model
 
 
-def sample_pointcloud(obj_id=0, obj_class='Mug'):
+def sample_pointcloud(obj_id=0, obj_class="Mug"):
     acronym_grasps = AcronymGraspsDirectory(data_type=obj_class)
     mesh = acronym_grasps.avail_obj[obj_id].load_mesh()
 
     centroid = mesh.centroid
     H = np.eye(4)
-    H[:3,-1] = -centroid
+    H[:3, -1] = -centroid
     mesh.apply_transform(H)
 
     scan_pointcloud = ScanPointcloud()
     P = scan_pointcloud.get_hq_scan_view(mesh)
 
-
-    P *= 8.
+    P *= 8.0
     P_mean = np.mean(P, 0)
     P += -P_mean
 
-    rot = scipy.spatial.transform.Rotation.random().as_matrix()
-    P = np.einsum('mn,bn->bm', rot, P)
+    rot = T.Rotation.random().as_matrix()
+    P = np.einsum("mn,bn->bm", rot, P)
 
-    mesh.apply_scale(8.)
+    mesh.apply_scale(8.0)
     H = np.eye(4)
-    H[:3,-1] = -P_mean
+    H[:3, -1] = -P_mean
     mesh.apply_transform(H)
     H = np.eye(4)
-    H[:3,:3] = rot
+    H[:3, :3] = rot
     mesh.apply_transform(H)
 
     return P, mesh
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     args = parse_args()
 
-    print('##########################################################')
-    print('Object Class: {}'.format(args.obj_class))
+    print("##########################################################")
+    print("Object Class: {}".format(args.obj_class))
     print(args.obj_id)
-    print('##########################################################')
+    print("##########################################################")
 
     n_grasps = int(args.n_grasps)
     obj_id = int(args.obj_id)
     obj_class = args.obj_class
-    n_envs = 30
+    device = args.device
+    batch_size = args.batch_size
 
     ## Set Model and Sample Generator ##
     P, mesh = sample_pointcloud(obj_id, obj_class)
-    generator, model = get_approximated_grasp_diffusion_field(P, device)
+    generator, model = get_approximated_grasp_diffusion_field(
+        P, batch_size=batch_size, device=device
+    )
 
-    H = generator.sample()
-    H[..., :3, -1] *=1/8.
+    H_batches = []
+    batches = int(np.ceil((n_grasps / batch_size)))
+    for i in range(0, batches):
+        H_batches.append(generator.sample())
+
+    H = torch.concatenate(H_batches, 0)
+    H[..., :3, -1] *= 1 / 8.0
 
     ## Visualize results ##
     from se3dif.visualization import grasp_visualization
 
     vis_H = H.squeeze()
-    P *=1/8
-    mesh = mesh.apply_scale(1/8)
-    grasp_visualization.visualize_grasps(to_numpy(H), p_cloud=P)#, mesh=mesh)
-
+    P *= 1 / 8
+    mesh = mesh.apply_scale(1 / 8)
+    grasp_visualization.visualize_grasps(to_numpy(H), p_cloud=P)  # , mesh=mesh)

--- a/scripts/sample/generate_pointcloud_6d_grasp_poses.py
+++ b/scripts/sample/generate_pointcloud_6d_grasp_poses.py
@@ -1,13 +1,13 @@
-import scipy.spatial.transform
+import configargparse
 import torch
+
 import numpy as np
+import scipy.spatial.transform as T
+
 from se3dif.datasets import AcronymGraspsDirectory
 from se3dif.models.loader import load_model
-from se3dif.samplers import ApproximatedGrasp_AnnealedLD, Grasp_AnnealedLD
+from se3dif.samplers import Grasp_AnnealedLD
 from se3dif.utils import to_numpy, to_torch
-import configargparse
-
-device = 'cpu'
 
 # Object Classes :['Cup', 'Mug', 'Fork', 'Hat', 'Bottle', 'Bowl', 'Car', 'Donut', 'Laptop', 'MousePad', 'Pencil',
 # 'Plate', 'ScrewDriver', 'WineBottle','Backpack', 'Bag', 'Banana', 'Battery', 'BeanBag', 'Bear',
@@ -16,88 +16,103 @@ device = 'cpu'
 # 'Sheep', 'Shower', 'Sink', 'SoapBottle', 'SodaCan','Spoon', 'Statue', 'Teacup', 'Teapot', 'ToiletPaper',
 # 'ToyFigure', 'Wallet','WineGlass','Cow', 'Sheep', 'Cat', 'Dog', 'Pizza', 'Elephant', 'Donkey', 'RubiksCube', 'Tank', 'Truck', 'USBStick']
 
+
 def parse_args():
     p = configargparse.ArgumentParser()
-    p.add('-c', '--config_filepath', required=False, is_config_file=True, help='Path to config file.')
+    p.add(
+        "-c",
+        "--config_filepath",
+        required=False,
+        is_config_file=True,
+        help="Path to config file.",
+    )
 
-    p.add_argument('--obj_id', type=str, default='0')
-    p.add_argument('--n_grasps', type=str, default='200')
-    p.add_argument('--obj_class', type=str, default='Laptop')
-    p.add_argument('--model', type=str, default='grasp_dif_multi')
-
+    p.add_argument("--obj_id", type=str, default="0")
+    p.add_argument("--n_grasps", type=str, default="200")
+    p.add_argument("--obj_class", type=str, default="Laptop")
+    p.add_argument("--model", type=str, default="point_graspdif")
+    p.add_argument("--device", type=str, default="cpu")
 
     opt = p.parse_args()
     return opt
 
 
-def get_approximated_grasp_diffusion_field(p, args, device='cpu'):
+def get_approximated_grasp_diffusion_field(p, args, batch_size=10, device="cpu"):
     model_params = args.model
-    batch = 10
+
     ## Load model
-    model_args = {
-        'device': device,
-        'pretrained_model': model_params
-    }
+    model_args = {"device": device, "pretrained_model": model_params}
     model = load_model(model_args)
 
-    context = to_torch(p[None,...], device)
-    model.set_latent(context, batch=batch)
+    context = to_torch(p[None, ...], device)
+    model.set_latent(context, batch_size)
 
     ########### 2. SET SAMPLING METHOD #############
-    generator = Grasp_AnnealedLD(model, batch=batch, T=70, T_fit=50, k_steps=2)
+    generator = Grasp_AnnealedLD(
+        model, device=device, batch=batch_size, T=70, T_fit=50, k_steps=1
+    )
 
+    # generator.set_latent_code(obj_id)
     return generator, model
 
 
-def sample_pointcloud(obj_id=0, obj_class='Mug'):
+def sample_pointcloud(obj_id=0, obj_class="Mug"):
     acronym_grasps = AcronymGraspsDirectory(data_type=obj_class)
     mesh = acronym_grasps.avail_obj[obj_id].load_mesh()
 
     P = mesh.sample(1000)
-    P *= 8.
+    P *= 8.0
     P_mean = np.mean(P, 0)
     P += -P_mean
 
-    rot = scipy.spatial.transform.Rotation.random().as_matrix()
-    P = np.einsum('mn,bn->bm', rot, P)
+    rot = T.Rotation.random().as_matrix()
+    P = np.einsum("mn,bn->bm", rot, P)
 
-    mesh.apply_scale(8.)
+    mesh.apply_scale(8.0)
     H = np.eye(4)
-    H[:3,-1] = -P_mean
+    H[:3, -1] = -P_mean
     mesh.apply_transform(H)
     H = np.eye(4)
-    H[:3,:3] = rot
+    H[:3, :3] = rot
     mesh.apply_transform(H)
 
     return P, mesh
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
 
     args = parse_args()
 
-    print('##########################################################')
-    print('Object Class: {}'.format(args.obj_class))
+    print("##########################################################")
+    print("Object Class: {}".format(args.obj_class))
     print(args.obj_id)
-    print('##########################################################')
+    print("##########################################################")
 
     n_grasps = int(args.n_grasps)
     obj_id = int(args.obj_id)
     obj_class = args.obj_class
-    n_envs = 30
+    device = args.device
+
+    batch_size = 10
 
     ## Set Model and Sample Generator ##
     P, mesh = sample_pointcloud(obj_id, obj_class)
-    generator, model = get_approximated_grasp_diffusion_field(P, args, device)
+    generator, model = get_approximated_grasp_diffusion_field(
+        P, args, batch_size=batch_size, device=device
+    )
 
-    H = generator.sample()
-    H[..., :3, -1] *=1/8.
+    H_batches = []
+    batches = int(np.ceil((n_grasps / batch_size)))
+    for i in range(0, batches):
+        H_batches.append(generator.sample())
+
+    H = torch.concatenate(H_batches, 0)
+    H[..., :3, -1] *= 1 / 8.0
 
     ## Visualize results ##
     from se3dif.visualization import grasp_visualization
 
     vis_H = H.squeeze()
-    P *=1/8
-    mesh = mesh.apply_scale(1/8)
+    P *= 1 / 8
+    mesh = mesh.apply_scale(1 / 8)
     grasp_visualization.visualize_grasps(to_numpy(H), p_cloud=P, mesh=mesh)
-


### PR DESCRIPTION
To resolve issue #4 

- added consistent use of `batch_size` and `device` variables
- added sampling loop to support desired n_grasps
- added `device` and `batch_size` as cli args
- Auto-sorted imports and format changes from black
